### PR TITLE
Added environment for publishing nugets

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -40,6 +40,7 @@ jobs:
       run: dotnet test --no-build --verbosity normal
   publish:
     if: startsWith(github.event.ref, 'refs/tags/v')
+    environment: nuget
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
By making the nuget publish job we can isolate the secret and make it easier to track the deployment over time.