### PR TITLE
Show active messages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,9 +14,9 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="Moq" Version="4.20.70" />
-    <PackageVersion Include="Spectre.Console" Version="0.48.0" />
-    <PackageVersion Include="Spectre.Console.Cli" Version="0.48.0" />
-    <PackageVersion Include="Spectre.Console.Json" Version="0.48.0" />
+    <PackageVersion Include="Spectre.Console" Version="0.49.0" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.49.0" />
+    <PackageVersion Include="Spectre.Console.Json" Version="0.49.0" />
     <PackageVersion Include="xunit" Version="2.7.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.8" />
   </ItemGroup>

--- a/src/AzOps.Sb/Commands/ServiceBusOverviewCommand.cs
+++ b/src/AzOps.Sb/Commands/ServiceBusOverviewCommand.cs
@@ -123,6 +123,12 @@ public class ServiceBusOverviewCommand : CancellableAsyncCommand<ServiceBusOverv
                 var subscriptionNode = topicNode.AddNode(subscription.Subscription);
                 subscriptionNode.AddNode(
                     $"Identifier: --namespace {settings.Namespace} --topic {topic.Topic} --subscription {subscription.Subscription}");
+
+                if (settings.ShowAll)
+                {
+                    subscriptionNode.AddNode($"[green]:check_mark: Active messages: {subscription.ActiveMessageCount}[/]");
+                }
+
                 if (subscription.DeadLetterMessageCount == 0)
                 {
                     subscriptionNode.AddNode("[green]:check_mark: Dead letters: 0[/]");

--- a/src/AzOps.Sb/Program.cs
+++ b/src/AzOps.Sb/Program.cs
@@ -43,18 +43,26 @@ It's possible to omit `--subscription-id` and `--resource-group` by adding them 
 [[namespace ""sb-magic-bus-test""]]
   resource-group = ""rg-integration-test""
   subscription-id = ""00000000-1111-2222-3333-444444444444""")
-                .WithExample(new[]
-                {
+                .WithExample([
                     "show",
-                    "--namespace", "sb-magic-bus-test",
-                    "--subscription-id", "00000000-1111-2222-3333-444444444444",
-                    "--resource-group", "rg-integration-test"
-                })
-                .WithExample(new[]
-                {
+                    "--namespace",
+                    "sb-magic-bus-test",
+                    "--subscription-id",
+                    "00000000-1111-2222-3333-444444444444",
+                    "--resource-group",
+                    "rg-integration-test"
+                ])
+                .WithExample([
                     "show",
-                    "--namespace", "sb-magic-bus-test"
-                });
+                    "--namespace",
+                    "sb-magic-bus-test"
+                ])
+                .WithExample([
+                    "show",
+                    "--namespace",
+                    "sb-magic-bus-test",
+                    "--all"
+                ]);
             appConfig.AddBranch<DeadLetterSettings>("deadletter", add =>
             {
                 add.AddCommand<DeadLetterListCommand>("list");

--- a/src/AzOps.Sb/Requests/ServiceBusOverviewRequest.cs
+++ b/src/AzOps.Sb/Requests/ServiceBusOverviewRequest.cs
@@ -30,8 +30,11 @@ public class
         {
             var subscriptions = resource.GetServiceBusSubscriptions();
             var subscriptionStatistics = subscriptions.Select(subscription =>
-                new SubscriptionStatistics(subscription.Data.Name,
-                    subscription.Data.CountDetails.DeadLetterMessageCount ?? 0)).ToList();
+                new SubscriptionStatistics(
+                    Subscription: subscription.Data.Name,
+                    DeadLetterMessageCount: subscription.Data.CountDetails.DeadLetterMessageCount ?? 0,
+                    ActiveMessageCount: subscription.Data.CountDetails.ActiveMessageCount ?? 0
+                )).ToList();
             return new TopicStatistics(resource.Data.Name, subscriptionStatistics);
         }).ToList();
 
@@ -41,6 +44,6 @@ public class
 
 public record TopicStatistics(string Topic, IReadOnlyCollection<SubscriptionStatistics> SubscriptionStatistics);
 
-public record SubscriptionStatistics(string Subscription, long DeadLetterMessageCount);
+public record SubscriptionStatistics(string Subscription, long DeadLetterMessageCount, long ActiveMessageCount);
 
 public record ServiceBusIdentifier(string SubscriptionId, string ResourceGroup, string Namespace);


### PR DESCRIPTION
When running `az-ops-sb show --namespace sb-magic-bus-prod --all` it can be good to get an overview of active messages as well.