### PR TITLE
Request copy from subscription to topic

### DIFF
--- a/src/AzOps.Sb/Commands/TransferCopyCommand.cs
+++ b/src/AzOps.Sb/Commands/TransferCopyCommand.cs
@@ -1,0 +1,38 @@
+using AzOps.Sb.Requests;
+using AzOps.Sb.Requests.Filters;
+using Azure.Messaging.ServiceBus;
+using MediatR;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzOps.Sb.Commands;
+
+public class TransferCopyCommand : CancellableAsyncCommand<TransferSettings>
+{
+    private readonly IAnsiConsole _ansiConsole;
+    private readonly IMediator _mediator;
+
+    public TransferCopyCommand(IAnsiConsole ansiConsole, IMediator mediator) : base(ansiConsole)
+    {
+        _ansiConsole = ansiConsole;
+        _mediator = mediator;
+    }
+    public override async Task<int> ExecuteAsync(CommandContext context, TransferSettings settings, CancellationToken cancellation)
+    {
+        var filter = MessageFilter.Builder.Create(settings.Limit).Build();
+        var request = new CopyMessageRequest(settings.ToSubscriptionId(), settings.ToDestinationTopic(), filter);
+        var messages = _mediator.CreateStream(request, cancellation);
+
+        await Render(_ansiConsole, messages);
+
+        return 0;
+    }
+
+    public async static Task Render(IAnsiConsole console, IAsyncEnumerable<ServiceBusReceivedMessage> messages)
+    {
+        await foreach (var message in messages)
+        {
+            console.WriteLine(message.MessageId);
+        }
+    }
+}

--- a/src/AzOps.Sb/Commands/TransferMoveCommand.cs
+++ b/src/AzOps.Sb/Commands/TransferMoveCommand.cs
@@ -1,0 +1,38 @@
+using AzOps.Sb.Requests;
+using AzOps.Sb.Requests.Filters;
+using Azure.Messaging.ServiceBus;
+using MediatR;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzOps.Sb.Commands;
+
+public class TransferMoveCommand : CancellableAsyncCommand<TransferSettings>
+{
+    private readonly IAnsiConsole _ansiConsole;
+    private readonly IMediator _mediator;
+
+    public TransferMoveCommand(IAnsiConsole ansiConsole, IMediator mediator) : base(ansiConsole)
+    {
+        _ansiConsole = ansiConsole;
+        _mediator = mediator;
+    }
+    public override async Task<int> ExecuteAsync(CommandContext context, TransferSettings settings, CancellationToken cancellation)
+    {
+        var filter = MessageFilter.Builder.Create(settings.Limit).Build();
+        var request = new MoveMessageRequest(settings.ToSubscriptionId(), settings.ToDestinationTopic(), filter);
+        var messages = _mediator.CreateStream(request, cancellation);
+
+        await Render(_ansiConsole, messages);
+
+        return 0;
+    }
+
+    public async static Task Render(IAnsiConsole console, IAsyncEnumerable<ServiceBusReceivedMessage> messages)
+    {
+        await foreach (var message in messages)
+        {
+            console.WriteLine(message.MessageId);
+        }
+    }
+}

--- a/src/AzOps.Sb/Commands/TransferSettings.cs
+++ b/src/AzOps.Sb/Commands/TransferSettings.cs
@@ -1,0 +1,76 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices.ComTypes;
+using AzOps.Sb.Requests;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzOps.Sb.Commands;
+
+
+
+public class TransferSettings : CommandSettings
+{
+    [Description("ServiceBus namespace")]
+    [CommandOption("-n|--namespace")]
+    public string? Namespace { get; init; }
+
+    [Description("ServiceBus subscription")]
+    [CommandOption("-s|--subscription")]
+    public string? Subscription { get; init; }
+
+    [Description("ServiceBus topic")]
+    [CommandOption("-t|--topic")]
+    public string? Topic { get; init; }
+
+    [Description("Destination topic")]
+    [CommandOption("-d|--destination-topic")]
+    public string? DestinationTopic { get; init; }
+
+    [Description("Limit")]
+    [CommandOption("-l|--limit")]
+    [DefaultValue(10)]
+    public int Limit { get; init; }
+
+    public override ValidationResult Validate()
+    {
+
+        if (string.IsNullOrEmpty(Namespace))
+        {
+            return ValidationResult.Error("--namespace is required");
+        }
+
+        if (string.IsNullOrEmpty(Subscription))
+        {
+            return ValidationResult.Error("--subscription is required");
+        }
+
+        if (string.IsNullOrEmpty(Topic))
+        {
+            return ValidationResult.Error("--topic is required");
+        }
+
+        if (string.IsNullOrEmpty(DestinationTopic))
+        {
+            return ValidationResult.Error("--destination-topic is required");
+        }
+
+        return ValidationResult.Success();
+    }
+
+    public SubscriptionId ToSubscriptionId()
+    {
+        ArgumentException.ThrowIfNullOrEmpty(Namespace);
+        ArgumentException.ThrowIfNullOrEmpty(Subscription);
+        ArgumentException.ThrowIfNullOrEmpty(Topic);
+
+        // TODO: Support SubQueueType
+        return new SubscriptionId(Namespace, Topic, Subscription, SubQueueType.None);
+    }
+
+    public TopicId ToDestinationTopic()
+    {
+        ArgumentException.ThrowIfNullOrEmpty(Namespace);
+        ArgumentException.ThrowIfNullOrEmpty(DestinationTopic);
+        return new TopicId(Namespace, DestinationTopic);
+    }
+}

--- a/src/AzOps.Sb/Program.cs
+++ b/src/AzOps.Sb/Program.cs
@@ -72,6 +72,38 @@ It's possible to omit `--subscription-id` and `--resource-group` by adding them 
                 add.AddCommand<DeadLetterRequeueCommand>("requeue");
                 add.AddCommand<DeadLetterDeleteCommand>("delete");
             });
+
+            appConfig.AddBranch<TransferSettings>("transfer", add =>
+            {
+                add.AddCommand<TransferCopyCommand>("copy")
+                    .WithDescription("Copy messages from a Subscription to a Topic")
+                    .WithExample([
+                        "transfer",
+                        "--namespace",
+                        "sb-magic-bus-test",
+                        "--topic",
+                        "topic-for-source-subscription",
+                        "--subscription",
+                        "source-subscription",
+                        "--destination-topic",
+                        "destination-topic",
+                        "copy"
+                    ]);
+                add.AddCommand<TransferMoveCommand>("move")
+                    .WithDescription("Move messages from a Subscription to a Topic")
+                    .WithExample([
+                        "transfer",
+                        "--namespace",
+                        "sb-magic-bus-test",
+                        "--topic",
+                        "topic-for-source-subscription",
+                        "--subscription",
+                        "source-subscription",
+                        "--destination-topic",
+                        "destination-topic",
+                        "move"
+                    ]);
+            });
 #if DEBUG
             appConfig.PropagateExceptions();
             appConfig.ValidateExamples();

--- a/src/AzOps.Sb/Requests/CopyMessageRequest.cs
+++ b/src/AzOps.Sb/Requests/CopyMessageRequest.cs
@@ -1,0 +1,78 @@
+using System.Runtime.CompilerServices;
+using AzOps.Sb.Requests.Filters;
+using Azure.Messaging.ServiceBus;
+using MediatR;
+
+namespace AzOps.Sb.Requests;
+
+public record CopyMessageRequest(SubscriptionId SourceSubscription, TopicId DestinationTopic, MessageFilter Filters)
+    : IStreamRequest<ServiceBusReceivedMessage>
+{
+}
+
+public class
+    CopyMessageRequestRequestHandler : IStreamRequestHandler<CopyMessageRequest, ServiceBusReceivedMessage>
+{
+    private readonly ServiceBusClientFactory _serviceBusClientFactory;
+
+    public CopyMessageRequestRequestHandler(ServiceBusClientFactory serviceBusClientFactory)
+    {
+        _serviceBusClientFactory =
+            serviceBusClientFactory ?? throw new ArgumentNullException(nameof(serviceBusClientFactory));
+    }
+
+    private static SubQueue CreateSubQueue(SubQueueType subQueueType)
+    {
+        return subQueueType switch
+        {
+            SubQueueType.None => SubQueue.None,
+            SubQueueType.DeadLetter => SubQueue.DeadLetter,
+            _ => throw new ArgumentOutOfRangeException(nameof(subQueueType), subQueueType, null)
+        };
+    }
+
+    public async IAsyncEnumerable<ServiceBusReceivedMessage> Handle(
+        CopyMessageRequest request,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var filter = new ServiceBusMessageFilter(request.Filters);
+        await using var serviceBusClient = _serviceBusClientFactory(request.SourceSubscription);
+
+        var serviceBusReceiver = serviceBusClient.CreateReceiver(request.SourceSubscription.Topic,
+            request.SourceSubscription.Subscription,
+            new ServiceBusReceiverOptions
+            {
+                ReceiveMode = ServiceBusReceiveMode.PeekLock,
+                SubQueue = CreateSubQueue(request.SourceSubscription.SubQueue)
+            });
+
+        await using var sender =
+            serviceBusClient.CreateSender(request.DestinationTopic.Topic, new ServiceBusSenderOptions
+            {
+                Identifier = ServiceBusApplication.ApplicationIdentifier
+            });
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var message = await serviceBusReceiver.PeekMessageAsync(cancellationToken: cancellationToken);
+
+            if (message == null)
+            {
+                yield break;
+            }
+
+            if (filter.IsValidMessage(message))
+            {
+                var messageToResend = new ServiceBusMessage(message);
+                await sender.SendMessageAsync(messageToResend, cancellationToken);
+                yield return message;
+            }
+            else
+            {
+                yield break;
+            }
+        }
+    }
+}

--- a/src/AzOps.Sb/Requests/DeadLetterId.cs
+++ b/src/AzOps.Sb/Requests/DeadLetterId.cs
@@ -1,5 +1,3 @@
 namespace AzOps.Sb.Requests;
 
-
-public record DeadLetterId(string Namespace, string Topic, string Subscription);
-
+public record DeadLetterId(string Namespace, string Topic, string Subscription) : IConnectSubscription;

--- a/src/AzOps.Sb/Requests/IConnectSubscription.cs
+++ b/src/AzOps.Sb/Requests/IConnectSubscription.cs
@@ -1,0 +1,8 @@
+namespace AzOps.Sb.Requests;
+
+public interface IConnectSubscription
+{
+    string Namespace { get; }
+    string Topic { get; }
+    string Subscription { get; }
+}

--- a/src/AzOps.Sb/Requests/MoveMessageRequest.cs
+++ b/src/AzOps.Sb/Requests/MoveMessageRequest.cs
@@ -1,0 +1,93 @@
+using System.Runtime.CompilerServices;
+using AzOps.Sb.Requests.Filters;
+using Azure.Messaging.ServiceBus;
+using MediatR;
+
+namespace AzOps.Sb.Requests;
+
+public record MoveMessageRequest(SubscriptionId SourceSubscription, TopicId DestinationTopic, MessageFilter Filters)
+    : IStreamRequest<ServiceBusReceivedMessage>
+{
+}
+
+public class
+    MoveMessageRequestHandler : IStreamRequestHandler<MoveMessageRequest, ServiceBusReceivedMessage>
+{
+    private readonly ServiceBusClientFactory _serviceBusClientFactory;
+
+    public MoveMessageRequestHandler(ServiceBusClientFactory serviceBusClientFactory)
+    {
+        _serviceBusClientFactory =
+            serviceBusClientFactory ?? throw new ArgumentNullException(nameof(serviceBusClientFactory));
+    }
+
+    private static SubQueue CreateSubQueue(SubQueueType subQueueType)
+    {
+        return subQueueType switch
+        {
+            SubQueueType.None => SubQueue.None,
+            SubQueueType.DeadLetter => SubQueue.DeadLetter,
+            _ => throw new ArgumentOutOfRangeException(nameof(subQueueType), subQueueType, null)
+        };
+    }
+
+    public async IAsyncEnumerable<ServiceBusReceivedMessage> Handle(
+        MoveMessageRequest request,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var filter = new ServiceBusMessageFilter(request.Filters);
+        await using var serviceBusClient = _serviceBusClientFactory(request.SourceSubscription);
+
+        var serviceBusReceiver = serviceBusClient.CreateReceiver(request.SourceSubscription.Topic,
+            request.SourceSubscription.Subscription,
+            new ServiceBusReceiverOptions
+            {
+                ReceiveMode = ServiceBusReceiveMode.PeekLock,
+                SubQueue = CreateSubQueue(request.SourceSubscription.SubQueue)
+            });
+
+        await using var sender =
+            serviceBusClient.CreateSender(request.DestinationTopic.Topic, new ServiceBusSenderOptions
+            {
+                Identifier = ServiceBusApplication.ApplicationIdentifier
+            });
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var message = await serviceBusReceiver.ReceiveMessageAsync(
+                maxWaitTime: TimeSpan.FromSeconds(3),
+                cancellationToken: cancellationToken);
+
+            if (message == null)
+            {
+                yield break;
+            }
+
+            if (filter.IsValidMessage(message))
+            {
+                try
+                {
+                    var messageToResend = new ServiceBusMessage(message);
+                    // Send the message to the new topic
+                    await sender.SendMessageAsync(messageToResend, cancellationToken);
+                    // Remove the message from the source subscription
+                    await serviceBusReceiver.CompleteMessageAsync(message, cancellationToken);
+                }
+                catch (Exception)
+                {
+                    await serviceBusReceiver.AbandonMessageAsync(message, cancellationToken: cancellationToken);
+                    throw;
+                }
+
+                yield return message;
+            }
+            else
+            {
+                await serviceBusReceiver.AbandonMessageAsync(message, cancellationToken: cancellationToken);
+                yield break;
+            }
+        }
+    }
+}

--- a/src/AzOps.Sb/Requests/ServiceBusClientFactory.cs
+++ b/src/AzOps.Sb/Requests/ServiceBusClientFactory.cs
@@ -2,4 +2,4 @@ using Azure.Messaging.ServiceBus;
 
 namespace AzOps.Sb.Requests;
 
-public delegate ServiceBusClient ServiceBusClientFactory(DeadLetterId azureSubscriptionId);
+public delegate ServiceBusClient ServiceBusClientFactory(IConnectSubscription azureSubscriptionId);

--- a/src/AzOps.Sb/Requests/SubQueue.cs
+++ b/src/AzOps.Sb/Requests/SubQueue.cs
@@ -1,0 +1,7 @@
+namespace AzOps.Sb.Requests;
+
+public enum SubQueueType
+{
+    None,
+    DeadLetter
+}

--- a/src/AzOps.Sb/Requests/SubscriptionId.cs
+++ b/src/AzOps.Sb/Requests/SubscriptionId.cs
@@ -1,0 +1,6 @@
+namespace AzOps.Sb.Requests;
+
+public record SubscriptionId(string Namespace, string Topic, string Subscription, SubQueueType SubQueue)
+    : IConnectSubscription;
+
+public record TopicId(string Namespace, string Topic);


### PR DESCRIPTION
Add support for transfer messages between a subscription an a new topic.
This could be useful for debugging and when you'll need to catch up with messages already produced.

```
USAGE:
    az-ops-sb transfer [OPTIONS] <COMMAND>

EXAMPLES:
    az-ops-sb transfer --namespace sb-magic-bus-test --topic 
topic-for-source-subscription --subscription source-subscription 
--destination-topic destination-topic copy
    az-ops-sb transfer --namespace sb-magic-bus-test --topic 
topic-for-source-subscription --subscription source-subscription 
--destination-topic destination-topic move

OPTIONS:
                               DEFAULT                           
    -h, --help                            Prints help information
    -n, --namespace                       ServiceBus namespace   
    -s, --subscription                    ServiceBus subscription
    -t, --topic                           ServiceBus topic       
    -d, --destination-topic               Destination topic      
    -l, --limit                10         Limit                  

COMMANDS:
    copy    Copy messages from a Subscription to a Topic
    move    Move messages from a Subscription to a Topic

```